### PR TITLE
 update usage handler and handle no args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
 dist
 sandy
-./.idea
+.idea
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 dist
 sandy
+./.idea

--- a/sandy.go
+++ b/sandy.go
@@ -140,6 +140,12 @@ func (i *arrayFlags) Set(value string) error {
 	return nil
 }
 
+// sandyUsage func is the usage handler for the sandy command
+func sandyUsage() {
+	fmt.Printf("Usage: %s [OPTIONS] command\n", os.Args[0])
+	flag.PrintDefaults()
+}
+
 func main() {
 	var allowedPattern arrayFlags
 	var blockedPattern arrayFlags
@@ -147,13 +153,15 @@ func main() {
 	// TODO add sane defaults like libc etc
 	allowedPattern = append(allowedPattern, "")
 
-	flag.Var(&allowedPattern, "y", "A glob pattern for automatically allowing file reads.")
-	flag.Var(&blockedPattern, "n", "A glob pattern for automatically blocking file reads.")
-	help := flag.Bool("h", false, "Print Usage.")
+	// overriding the Usage handler
+	flag.Usage = sandyUsage
+	flag.Var(&blockedPattern, "n", "A glob pattern for automatically blocking file reads.\nFor example, \"/etc/password.txt\" or \"*.txt\".")
+	flag.Var(&allowedPattern, "y", "A glob pattern for automatically allowing file reads.\nExpected format is same as -n.")
+	showHelp := flag.Bool("h", false, "Print Usage.")
 
 	flag.Parse()
 
-	if *help == true {
+	if flag.NArg() < 1  || *showHelp {
 		flag.Usage()
 		return
 	}

--- a/sandy_test.go
+++ b/sandy_test.go
@@ -13,7 +13,7 @@ func TestExec(t *testing.T) {
 	reqs, err := Exec("cat", s, patterns, patterns)
 
 	if err != nil {
-		t.Errorf("Something went wrong")
+		t.Errorf("Something went wrong: %v", err)
 	}
 
 	if len(reqs) != 2 {
@@ -31,7 +31,7 @@ func TestInput(t *testing.T) {
 
 	err := cmd.Run()
 	if err != nil {
-		t.Errorf("Something went wrong")
+		t.Errorf("Something went wrong: %v", err)
 	}
 	if strings.Contains(out.String(), "Blocked READ on ...") {
 		t.Errorf("Expected %s output got %s", "Blocked READ on ...", out.String())
@@ -46,7 +46,7 @@ func TestAllowList(t *testing.T) {
 	cmd.Stdout = &out
 	err := cmd.Run()
 	if err != nil {
-		t.Errorf("Something went wrong")
+		t.Errorf("Something went wrong: %v", err)
 	}
 	if out.String() != "123\n" {
 		t.Errorf("Expected %s output got %s", "123", out.String())
@@ -59,10 +59,10 @@ func TestBlockList(t *testing.T) {
 	cmd.Stdout = &out
 	err := cmd.Run()
 	if err != nil {
-		t.Errorf("Something went wrong")
+		t.Errorf("Something went wrong: %v", err)
 	}
 	if !strings.Contains(out.String(), "Blocked READ on ") {
-		t.Errorf("Expected %s output got %s", "123", out.String())
+		t.Errorf("Expected %s output got %s", "Blocked READ on", out.String())
 	}
 }
 
@@ -73,7 +73,7 @@ func TestHelp(t *testing.T) {
 	err := cmd.Run()
 
 	if err != nil {
-		t.Errorf("Something went wrong")
+		t.Errorf("Something went wrong: %v", err)
 	}
 
 	if strings.Contains(out.String(), "Usage of ./sandy:") {


### PR DESCRIPTION
The PR
    - updates the usage handler
    - adds example input for `-n` and `-y` flags

```bash
$ ./sandy 
Usage: ./sandy [OPTIONS] command
  -h	Print Usage.
  -n value
    	A glob pattern for automatically blocking file reads.
    	For example, "/etc/password.txt" or "*.txt".
  -y value
    	A glob pattern for automatically allowing file reads.
    	Expected format is same as -n.

$ ./sandy -h
Usage: ./sandy [OPTIONS] command
  -h	Print Usage.
  -n value
    	A glob pattern for automatically blocking file reads.
    	For example, "/etc/password.txt" or "*.txt".
  -y value
    	A glob pattern for automatically allowing file reads.
    	Expected format is same as -n.
```

Fixes #1 